### PR TITLE
Version 6.5, Augured Homecoming (v6.5.0)

### DIFF
--- a/mona_core/src/buffs/buffs/character/geo/linnea.rs
+++ b/mona_core/src/buffs/buffs/character/geo/linnea.rs
@@ -319,8 +319,8 @@ impl BuffMeta for BuffLinneaC6 {
     const META_DATA: BuffMetaData = BuffMetaData {
         name: BuffName::LinneaC6,
         name_locale: locale!(
-            zh_cn: "莉奈娅-「专家的直感觉」",
-            en: "Linnea-Expert Instinct"
+            zh_cn: "莉奈娅-「黄金猎犬之梦」",
+            en: "Linnea-Golden Beagle's Dream"
         ),
         image: BuffImage::Avatar(CharacterName::Linnea),
         genre: BuffGenre::Character,


### PR DESCRIPTION
#### Features for version 6.5

**Characters:**

- 莉奈娅 Linnea

**Weapons:**

- 霜结的誓金枝 Lightbearing Moonshard

**Buffs:**

- 莉奈娅-「野外观察手记」 Linnea-Field Observation Notes
- 莉奈娅-「万类博物图鉴」 Linnea-Universal Naturalist Archive
- 莉奈娅-「月兆祝赐·栖地考察」 Linnea-Moonsign Benediction: Habitat Survey
- 莉奈娅-「未完成的分类」 Linnea-Provisional Classification
- 莉奈娅-「喜或悲的谕告」 Linnea-Tidings of Joy and Sorrow
- 莉奈娅-「专家的直感觉」 Linnea-Expert Instinct
- 莉奈娅-「黄金猎犬之梦」 Linnea-Golden Beagle's Dream
- 霜结的誓金枝-「霜妖精的恶戏」 Golden Frostbound Oath-Frost Fae's Mischief

#### Fixes

- 修复了法尔伽未染色时伤害元素类型错误的问题
- 修复了法尔伽默认计算函数未正确处理法尔伽六命的问题
- 修复了 Buff 黑蚀-「白昼之刃」数值错误的问题 (Resolve #26)
- 修复了兹白默认计算函数月结晶反应伤害次数错误的问题
- 将所有起点为基础攻击力、基础生命值上限、基础防御力的出边的默认优先级调高
